### PR TITLE
Don't override locality with postal_town value

### DIFF
--- a/pkg/provider/google.go
+++ b/pkg/provider/google.go
@@ -135,7 +135,12 @@ func updateFromComponents(location *geocoder.Location, components []maps.Address
 			switch vv {
 			case "postal_code":
 				location.PostalCode = v.LongName
-			case "locality", "postal_town":
+			case "locality":
+				location.Locality = v.LongName
+			case "postal_town":
+				if location.Locality == "" {
+					location.Locality = v.LongName
+				}
 				location.Locality = v.LongName
 			case "street_number":
 				location.StreetNumber = v.LongName

--- a/pkg/provider/google.go
+++ b/pkg/provider/google.go
@@ -141,7 +141,6 @@ func updateFromComponents(location *geocoder.Location, components []maps.Address
 				if location.Locality == "" {
 					location.Locality = v.LongName
 				}
-				location.Locality = v.LongName
 			case "street_number":
 				location.StreetNumber = v.LongName
 			case "route":


### PR DESCRIPTION
Put postal_town into geocoder's locality only if original locality is empty.
